### PR TITLE
minor: Update npm usage to modern syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following features are supported:
 
 **Using NPM:**
 ```bash
-npm install @lifeomic/attempt --save
+npm i @lifeomic/attempt
 ```
 
 **Using Yarn:**


### PR DESCRIPTION
Supported in all not deprecated node/npm versions... and then some. 

Old syntax makes npm look like a dinosaur