### PR TITLE
Handling synchronous handleTimeout function errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,7 +165,13 @@ export async function retry<T> (
       return new Promise((resolve, reject) => {
         const timer = setTimeout(() => {
           if (options.handleTimeout) {
-            resolve(options.handleTimeout(context, options));
+            // If calling handleTimeout throws an error that is not wrapped in a promise
+            // we want to catch the error and reject.
+            try {
+              resolve(options.handleTimeout(context, options));
+            } catch (e) {
+              reject(e);
+            }
           } else {
             const err: any = new Error(`Retry timeout (attemptNum: ${context.attemptNum}, timeout: ${options.timeout})`);
             err.code = 'ATTEMPT_TIMEOUT';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -552,3 +552,16 @@ test('should allow for return type to be specified', async (t) => {
   t.is(result.str, 'string');
   t.is(result.num, 25);
 });
+
+test('should allow handleTimeout to throw an error that can be caught', async (t) => {
+  const expectedError = new Error();
+
+  const actualError = await t.throws(retry(async () => {
+    await sleep(20);
+  }, {
+    handleTimeout: () => { throw expectedError; },
+    timeout: 10
+  }));
+
+  t.is(expectedError, actualError);
+});


### PR DESCRIPTION
@mdlavin Hey I noticed that we are allowed supply the handleTimeout option with a synchronous handler that throws an error, but this will end up throwing an Uncaught exception even though it's wrapped in a `try/catch`

```
    try {
    await retry(
      async () => new Promise((resolve) => setTimeout(resolve, 20)),
      {
        timeout: 10,
        handleTimeout: () => {
          throw new Error('App timeout');
        },
      }
    );
  } catch (e) {
    console.log('Caught the error', e);
  }
```

