### PR TITLE
chore: NO-TICKET - fix the semantic release config.

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -2,7 +2,7 @@ module.exports = {
   branches: ['master'],
   plugins: [
     ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],
-    ['@semantic-release/npm', { pkgRoot: 'dist/' }],
+    ['@semantic-release/npm'],
     [
       '@semantic-release/github',
       {


### PR DESCRIPTION
The `package.json` entries point to the `./dist` directory, but we aren't publishing from `dist`, we're publishing from the root of the project and only including the necessary files.  This removes the config publishing under the dist directory.