### PR TITLE
add initialJitter feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following object shows the default options:
   factor: 0,
   timeout: 0,
   jitter: false,
+  initialJitter: false,
   handleError: null,
   handleTimeout: null,
   beforeAttempt: null,
@@ -152,6 +153,13 @@ to your target environment.
    The following formula is used to calculate delay using `jitter`:
 
    `delay = Math.random() * (delay - minDelay) + minDelay`
+
+   (default: `false`)
+
+- **`initialJitter`**: `Boolean`
+
+  If `initialJitter` is `true` then a `jitter` will also be used in the
+  first call attempt.
 
    (default: `false`)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export interface AttemptOptions<T> {
   readonly maxAttempts: number;
   readonly timeout: number;
   readonly jitter: boolean;
+  readonly initialJitter: boolean;
   readonly handleError: HandleError<T> | null;
   readonly handleTimeout: HandleTimeout<T> | null;
   readonly beforeAttempt: BeforeAttempt<T> | null;
@@ -44,6 +45,7 @@ function applyDefaults<T> (options?: PartialAttemptOptions<T>): AttemptOptions<T
     maxAttempts: (options.maxAttempts === undefined) ? 3 : options.maxAttempts,
     timeout: (options.timeout === undefined) ? 0 : options.timeout,
     jitter: (options.jitter === true),
+    initialJitter: (options.initialJitter === true),
     handleError: (options.handleError === undefined) ? null : options.handleError,
     handleTimeout: (options.handleTimeout === undefined) ? null : options.handleTimeout,
     beforeAttempt: (options.beforeAttempt === undefined) ? null : options.beforeAttempt,
@@ -205,5 +207,11 @@ export async function retry<T> (
     await sleep(initialDelay);
   }
 
+  if (context.attemptNum < 1 && options.initialJitter) {
+    const delay = calculateDelay(context, options);
+    if (delay) {
+      await sleep(delay);
+    }
+  }
   return makeAttempt();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,9 +54,7 @@ function applyDefaults<T> (options?: PartialAttemptOptions<T>): AttemptOptions<T
 }
 
 export async function sleep (delay: number) {
-  return new Promise((resolve, reject) => {
-    setTimeout(resolve, delay);
-  });
+  return new Promise((resolve) => setTimeout(resolve, delay));
 }
 
 export function defaultCalculateDelay<T> (context: AttemptContext, options: AttemptOptions<T>): number {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -353,7 +353,6 @@ test('should support jitter with initialJitter', async (t) => {
     lastTime = newTime;
 
     t.true(actualDelay <= (expectedDelays[context.attemptNum] + DELAY_TOLERANCE));
-    t.true(actualDelay > 0);
 
     if (context.attemptsRemaining === 0) {
       return 'success';
@@ -428,7 +427,6 @@ test('should support jitter with minDelay and initialJitter', async (t) => {
     }
 
     t.true(actualDelay <= (expectedDelays[context.attemptNum] + DELAY_TOLERANCE));
-    t.true(actualDelay > 0);
 
     if (context.attemptsRemaining === 0) {
       return 'success';


### PR DESCRIPTION
I accidentally closed #57, opening a new one :-)

We ran into a case where we need to use an `initialJitter` to randomize a delay for the first call attempt too.

PR adds this.

- [x] Test
- [x] Code
- [x] Docs 
